### PR TITLE
(#1) feat: add process-based session detection and PATH setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@
 ```bash
 # Install via Go
 go install github.com/seunggabi/claude-dashboard/cmd/claude-dashboard@latest
+
+# Add Go bin to PATH (if not already configured)
+export PATH="$HOME/go/bin:$PATH"
+
+# To make it permanent, add to your shell profile:
+# echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.zshrc   # zsh
+# echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc  # bash
 ```
 
 Or build from source:

--- a/internal/session/detector.go
+++ b/internal/session/detector.go
@@ -31,7 +31,8 @@ func (d *Detector) Detect() ([]Session, error) {
 
 	for _, raw := range rawSessions {
 		// Include sessions with cd- prefix or that contain claude in the name
-		if !strings.HasPrefix(raw.Name, SessionPrefix) && !strings.Contains(strings.ToLower(raw.Name), "claude") {
+		isNameMatch := strings.HasPrefix(raw.Name, SessionPrefix) || strings.Contains(strings.ToLower(raw.Name), "claude")
+		if !isNameMatch && !d.client.HasClaudeProcess(raw.Name) {
 			continue
 		}
 


### PR DESCRIPTION
Closes #1

## Changes
- README Quick Start에 `$HOME/go/bin` PATH 설정 안내 추가
- `tmux/client.go`: `HasClaudeProcess()` 메서드 추가 - pane command 확인 후 BFS 프로세스 트리 탐색
- `session/detector.go`: 이름 매칭 실패 시 프로세스 기반 감지로 fallback

## 감지 흐름
1. 세션 이름이 `cd-*` 이거나 "claude" 포함 → 즉시 포함 (fast path)
2. 이름 불일치 → `#{pane_current_command}` 확인
3. 그래도 불일치 → pane PID 프로세스 트리 BFS 탐색

🤖 Generated with [Claude Code](https://claude.com/claude-code)