### PR TITLE
(#3) feat: add terminal session detection for non-tmux Claude processes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -239,6 +239,10 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		sessions := m.filteredSessions()
 		if len(sessions) > 0 && m.cursor < len(sessions) {
+			if !sessions[m.cursor].Managed {
+				m.err = fmt.Errorf("terminal sessions cannot be attached (not a tmux session)")
+				return m, nil
+			}
 			return m, m.attachSession(sessions[m.cursor].Name)
 		}
 	case "n":
@@ -248,12 +252,20 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "K":
 		sessions := m.filteredSessions()
 		if len(sessions) > 0 && m.cursor < len(sessions) {
+			if !sessions[m.cursor].Managed {
+				m.err = fmt.Errorf("terminal sessions cannot be killed from dashboard")
+				return m, nil
+			}
 			m.confirming = true
 			m.confirmMsg = fmt.Sprintf("Kill session '%s'? (y/n)", sessions[m.cursor].Name)
 		}
 	case "l":
 		sessions := m.filteredSessions()
 		if len(sessions) > 0 && m.cursor < len(sessions) {
+			if !sessions[m.cursor].Managed {
+				m.err = fmt.Errorf("logs not available for terminal sessions")
+				return m, nil
+			}
 			m.view = ViewLogs
 			s := sessions[m.cursor]
 			m.logView = ui.NewLogView(s.Name, m.width, m.height)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -12,7 +12,8 @@ const (
 	StatusActive  Status = "active"
 	StatusIdle    Status = "idle"
 	StatusWaiting Status = "waiting"
-	StatusUnknown Status = "unknown"
+	StatusUnknown  Status = "unknown"
+	StatusTerminal Status = "terminal"
 )
 
 // Session represents a Claude Code tmux session.
@@ -27,6 +28,7 @@ type Session struct {
 	CPU       float64
 	Memory    float64
 	Path      string
+	Managed   bool // true = tmux session (can attach/detach), false = terminal process (read-only)
 }
 
 // Uptime returns the human-readable uptime string.
@@ -55,6 +57,8 @@ func (s *Session) StatusString() string {
 		return "○ idle"
 	case StatusWaiting:
 		return "◎ waiting"
+	case StatusTerminal:
+		return "⊘ terminal"
 	default:
 		return "? unknown"
 	}


### PR DESCRIPTION
Closes #3

## Changes
- `session/detector.go`: `DetectTerminalSessions()` 추가 - `ps` + `lsof`로 tmux 밖 Claude 프로세스 감지
- `session/session.go`: `Managed` 필드 및 `StatusTerminal` (`⊘ terminal`) 상태 추가
- `app/app.go`: 터미널 세션에 대해 attach/kill/logs 동작 차단 (read-only 표시)

## 동작
- tmux 세션: 기존과 동일 (attach, kill, logs 모두 가능)
- 터미널 세션: `⊘ terminal` 상태로 표시, read-only (상태 확인만 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)