### PR TITLE
(#5) fix: clear terminal escape sequences before tmux attach

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -557,6 +557,8 @@ func Run() error {
 
 // ExecAttach replaces the current process with tmux attach.
 func ExecAttach(name string) error {
+	// Reset terminal to clear stale escape sequences (e.g. [?6c)
+	fmt.Print("\033c")
 	cmd := fmt.Sprintf("tmux attach-session -t %s", name)
 	return execCommand(cmd)
 }


### PR DESCRIPTION
Closes #5

## Changes
- `ExecAttach()`에서 tmux attach 전에 `\033c` 터미널 리셋 추가
- `[?6c` 이스케이프 시퀀스 노출 문제 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)