### PR TITLE
(#7) fix: detect terminal sessions even when tmux is not running

### DIFF
--- a/internal/session/detector.go
+++ b/internal/session/detector.go
@@ -22,10 +22,11 @@ func NewDetector(client *tmux.Client) *Detector {
 func (d *Detector) Detect() ([]Session, error) {
 	output, err := d.client.ListSessions(tmux.SessionFormat)
 	if err != nil {
-		return nil, err
+		// Even if tmux fails, still detect terminal sessions
+		return d.detectTerminalOnly()
 	}
 	if output == "" {
-		return nil, nil
+		return d.detectTerminalOnly()
 	}
 
 	rawSessions := tmux.ParseSessions(output)
@@ -72,6 +73,12 @@ func (d *Detector) Detect() ([]Session, error) {
 	terminalSessions := d.DetectTerminalSessions(tmuxPIDs)
 	sessions = append(sessions, terminalSessions...)
 
+	return sessions, nil
+}
+
+// detectTerminalOnly returns only terminal sessions (when tmux is unavailable).
+func (d *Detector) detectTerminalOnly() ([]Session, error) {
+	sessions := d.DetectTerminalSessions(make(map[string]bool))
 	return sessions, nil
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -30,10 +30,12 @@ func (c *Client) IsRunning() bool {
 // ListSessions returns raw tmux session list with format.
 func (c *Client) ListSessions(format string) (string, error) {
 	cmd := exec.Command(c.tmuxPath, "list-sessions", "-F", format)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		if strings.Contains(err.Error(), "no server running") ||
-			strings.Contains(string(out), "no server running") {
+		combined := string(out)
+		if strings.Contains(combined, "no server running") ||
+			strings.Contains(combined, "no current client") ||
+			strings.Contains(err.Error(), "exit status") {
 			return "", nil
 		}
 		return "", err


### PR DESCRIPTION
Closes #7

## Changes
- `tmux/client.go`: `CombinedOutput()` 사용으로 stderr의 "no server running" 메시지 정상 감지
- `session/detector.go`: tmux 실패/미실행 시에도 `detectTerminalOnly()`로 터미널 세션 감지 진행

## 원인
tmux 서버 미실행 → `ListSessions` 에러 → `Detect()` 즉시 반환 → 터미널 세션 감지 코드 미도달

🤖 Generated with [Claude Code](https://claude.com/claude-code)