### PR TITLE
(#11) chore: rewrite README, auto-attach new command, fix escape sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.test
 *.out
 .DS_Store
+.claude/


### PR DESCRIPTION
Closes #11

## Changes

### README 리뉴얼
- 모든 기능 반영 (프로세스 감지, 터미널 세션, 대화 기록 뷰어, CLI new)
- 프로젝트 구조 실제 파일과 동기화

### `new` 커맨드 개선
- `--attach` 플래그 제거, 항상 자동 attach
- 기존 세션 존재 시 에러 대신 해당 세션으로 접속

### `[?6c]` escape sequence 완전 수정
- `\033c` 터미널 리셋 + `drainStdin()` stdin 버퍼 드레인
- Bubble Tea 종료 후 남은 DA1 응답 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)