### PR TITLE
(#20) docs: add modcache clean to upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make install
 Upgrade to latest:
 
 ```bash
-go install github.com/seunggabi/claude-dashboard/cmd/claude-dashboard@latest
+GOFLAGS=-mod=mod go clean -modcache && go install github.com/seunggabi/claude-dashboard/cmd/claude-dashboard@latest
 ```
 
 First run:


### PR DESCRIPTION
Closes #20

## Changes
- README 업그레이드 명령어에 `go clean -modcache` 추가하여 캐시된 모듈로 인한 설치 문제 방지