### PR TITLE
(#22) feat: add dynamic mouse toggle between dashboard and logs view

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -124,6 +124,7 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.refreshSessions,
 		monitor.TickCmd(m.cfg.RefreshInterval),
+		tea.EnableMouseCellMotion,
 	)
 }
 
@@ -311,9 +312,9 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.view = ViewLogs
 			m.logView = ui.NewLogView(s.Name, m.width, m.height)
 			if s.Managed {
-				return m, m.fetchLogs(s.Name)
+				return m, tea.Batch(tea.DisableMouse, m.fetchLogs(s.Name))
 			}
-			return m, m.fetchConversation(s.Path)
+			return m, tea.Batch(tea.DisableMouse, m.fetchConversation(s.Path))
 		}
 	case "d":
 		sessions := m.filteredSessions()
@@ -334,8 +335,11 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handleLogsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "esc", "q":
+	case "esc":
 		m.view = ViewDashboard
+		return m, tea.EnableMouseCellMotion
+	case "q":
+		return m, tea.Quit
 	default:
 		var cmd tea.Cmd
 		m.logView.Viewport, cmd = m.logView.Viewport.Update(msg)
@@ -356,7 +360,7 @@ func (m Model) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.view = ViewLogs
 			s := sessions[m.cursor]
 			m.logView = ui.NewLogView(s.Name, m.width, m.height)
-			return m, m.fetchLogs(s.Name)
+			return m, tea.Batch(tea.DisableMouse, m.fetchLogs(s.Name))
 		}
 	case "K":
 		sessions := m.filteredSessions()
@@ -645,7 +649,6 @@ func Run() error {
 
 		p := tea.NewProgram(m,
 			tea.WithAltScreen(),
-			tea.WithMouseCellMotion(),
 		)
 
 		result, err := p.Run()

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -37,7 +37,7 @@ func HelpBar(width int, context string) string {
 	case "dashboard":
 		hints = "enter:attach  n:new  K:kill  l:logs  d:detail  /:filter  r:refresh  ?:help  q:quit"
 	case "logs":
-		hints = "↑/↓:scroll  esc:back  q:quit"
+		hints = "↑/↓/j/k:scroll  select:copy  esc:back  q:quit"
 	case "detail":
 		hints = "esc:back  l:logs  K:kill  q:quit"
 	case "create":


### PR DESCRIPTION
Closes #22

## Changes
- 대시보드: 마우스 스크롤 활성화 (Init에서 EnableMouseCellMotion)
- 로그 뷰 진입 시: DisableMouse → 텍스트 블록 선택 + 복사 가능
- 로그 뷰 → 대시보드 복귀 시: EnableMouseCellMotion 자동 복원
- 디테일 뷰에서 로그 전환 시에도 동일하게 적용
- help bar에 select:copy 힌트 추가