### PR TITLE
(#26) feat: add cdn alias setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ claude-dashboard new my-project --path ~/code/foo --args "--model sonnet"
 claude-dashboard attach cd-my-project
 ```
 
+### Alias (Optional)
+
+`cdn` as a shortcut for `claude-dashboard new`:
+
+```bash
+source <(curl -fsSL https://raw.githubusercontent.com/seunggabi/claude-dashboard/main/alias.sh)
+```
+
 ### General
 
 ```bash

--- a/alias.sh
+++ b/alias.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+ALIAS_LINE_BASH="alias cdn='claude-dashboard new'"
+ALIAS_LINE_FISH="alias cdn 'claude-dashboard new'"
+SHELL_NAME="$(basename "$SHELL")"
+
+case "$SHELL_NAME" in
+  zsh)
+    RC_FILE="$HOME/.zshrc"
+    ALIAS_LINE="$ALIAS_LINE_BASH"
+    ;;
+  bash)
+    if [ -f "$HOME/.bash_profile" ]; then
+      RC_FILE="$HOME/.bash_profile"
+    else
+      RC_FILE="$HOME/.bashrc"
+    fi
+    ALIAS_LINE="$ALIAS_LINE_BASH"
+    ;;
+  fish)
+    RC_FILE="$HOME/.config/fish/config.fish"
+    ALIAS_LINE="$ALIAS_LINE_FISH"
+    ;;
+  *)
+    RC_FILE="$HOME/.${SHELL_NAME}rc"
+    ALIAS_LINE="$ALIAS_LINE_BASH"
+    ;;
+esac
+
+if [ ! -f "$RC_FILE" ]; then
+  touch "$RC_FILE"
+fi
+
+if grep -qF "alias cdn" "$RC_FILE" 2>/dev/null; then
+  echo "cdn alias already exists in $RC_FILE"
+else
+  echo "" >> "$RC_FILE"
+  echo "$ALIAS_LINE" >> "$RC_FILE"
+  echo "Added cdn alias to $RC_FILE"
+fi
+
+# Apply alias to current shell
+eval "$ALIAS_LINE"
+echo "cdn is ready to use!"


### PR DESCRIPTION
## Summary
- `alias.sh` 추가: `cdn` → `claude-dashboard new` alias 자동 설정
- bash/zsh/fish 자동 감지, 중복 방지
- `source <(curl ...)` 로 즉시 적용
- README에 Alias (Optional) 섹션 추가

Closes #26

## Test plan
- [ ] `bash alias.sh` 실행 시 rc 파일에 alias 추가 확인
- [ ] 2회 실행 시 중복 방지 확인
- [ ] `source <(bash alias.sh)` 로 즉시 cdn 사용 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)