### PR TITLE
(#31) refactor: simplify F12 mouse toggle setup with separate scripts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,9 @@ builds:
 archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - scripts/tmux-mouse-toggle.sh
+      - scripts/tmux-status-bar.sh
 
 checksum:
   name_template: "checksums.txt"
@@ -44,3 +47,5 @@ brews:
     license: "MIT"
     install: |
       bin.install "claude-dashboard"
+      bin.install "scripts/tmux-mouse-toggle.sh" => "claude-dashboard-mouse-toggle"
+      bin.install "scripts/tmux-status-bar.sh" => "claude-dashboard-status-bar"

--- a/README.md
+++ b/README.md
@@ -189,14 +189,13 @@ Mouse mode is enabled by default for smooth scrolling. To copy text:
 Add these lines to your `~/.tmux.conf`:
 
 ```bash
-# F12 key binding for mouse mode toggle with immediate status update
-bind-key -n F12 run-shell "if tmux show-option -gv mouse | grep -q on; then tmux set-option -g mouse off && tmux display-message 'Mouse: OFF'; else tmux set-option -g mouse on && tmux display-message 'Mouse: ON'; fi; tmux refresh-client -S"
+# F12 key binding for mouse mode toggle
+bind-key -n F12 run-shell "~/.local/bin/claude-dashboard-mouse-toggle"
 
-# Status bar with dynamic version check and mouse status
-# Automatically checks for updates every hour
-set -g status-right-length 80  # Increase right area to prevent truncation
-set -g status-right "#(~/.local/bin/claude-dashboard-version-check) | [F12] Mouse:#{?mouse,ON,OFF} | %H:%M"
-set -g status-interval 5  # Update every 5 seconds for quick status refresh
+# Status bar with version check and mouse status (updates every hour)
+set -g status-right-length 80
+set -g status-right "#(~/.local/bin/claude-dashboard-status-bar) | [F12] Mouse:#{?mouse,ON,OFF} | %H:%M"
+set -g status-interval 5
 
 # Enable mouse mode by default
 set -g mouse on

--- a/install.sh
+++ b/install.sh
@@ -178,6 +178,15 @@ extract_and_install() {
     print_info "Installing to $install_path..."
     ensure mv "$binary_path" "$install_path"
 
+    # Install helper scripts if they exist in the archive
+    if [ -d "$temp_dir/scripts" ]; then
+        print_info "Installing helper scripts..."
+        ensure cp "$temp_dir/scripts/tmux-mouse-toggle.sh" "$INSTALL_DIR/claude-dashboard-mouse-toggle"
+        ensure cp "$temp_dir/scripts/tmux-status-bar.sh" "$INSTALL_DIR/claude-dashboard-status-bar"
+        ensure chmod +x "$INSTALL_DIR/claude-dashboard-mouse-toggle"
+        ensure chmod +x "$INSTALL_DIR/claude-dashboard-status-bar"
+    fi
+
     print_info "Installation complete!"
 }
 

--- a/scripts/tmux-mouse-toggle.sh
+++ b/scripts/tmux-mouse-toggle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Toggle tmux mouse mode and display status
+
+if tmux show-option -gv mouse | grep -q on; then
+    tmux set-option -g mouse off
+    tmux display-message "Mouse: OFF"
+else
+    tmux set-option -g mouse on
+    tmux display-message "Mouse: ON"
+fi
+
+# Refresh client to update status bar immediately
+tmux refresh-client -S

--- a/scripts/tmux-status-bar.sh
+++ b/scripts/tmux-status-bar.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Display claude-dashboard version and update notification in tmux status bar
+
+VERSION_FILE="$HOME/.cache/claude-dashboard/version"
+CURRENT_VERSION_FILE="$HOME/.cache/claude-dashboard/current-version"
+LAST_CHECK_FILE="$HOME/.cache/claude-dashboard/last-check"
+
+# Create cache directory if it doesn't exist
+mkdir -p "$HOME/.cache/claude-dashboard"
+
+# Check for updates every hour
+CURRENT_TIME=$(date +%s)
+LAST_CHECK=0
+if [ -f "$LAST_CHECK_FILE" ]; then
+    LAST_CHECK=$(cat "$LAST_CHECK_FILE")
+fi
+
+# 3600 seconds = 1 hour
+if [ $((CURRENT_TIME - LAST_CHECK)) -gt 3600 ]; then
+    # Get current installed version
+    if command -v claude-dashboard &> /dev/null; then
+        CURRENT=$(claude-dashboard --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "v0.0.0")
+        echo "$CURRENT" > "$CURRENT_VERSION_FILE"
+    fi
+
+    # Get latest version from GitHub
+    LATEST=$(curl -s https://api.github.com/repos/seunggabi/claude-dashboard/releases/latest | grep -oE '"tag_name": "v[0-9]+\.[0-9]+\.[0-9]+"' | cut -d'"' -f4 || echo "")
+
+    if [ -n "$LATEST" ]; then
+        echo "$LATEST" > "$VERSION_FILE"
+    fi
+
+    echo "$CURRENT_TIME" > "$LAST_CHECK_FILE"
+fi
+
+# Read cached version info
+CURRENT="v0.0.0"
+LATEST=""
+if [ -f "$CURRENT_VERSION_FILE" ]; then
+    CURRENT=$(cat "$CURRENT_VERSION_FILE")
+fi
+if [ -f "$VERSION_FILE" ]; then
+    LATEST=$(cat "$VERSION_FILE")
+fi
+
+# Display version with update notification
+if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
+    echo "📦 $CURRENT → $LATEST"
+else
+    echo "✓ $CURRENT"
+fi


### PR DESCRIPTION
## Summary
Simplifies F12 mouse toggle setup by extracting complex bash logic into separate, maintainable scripts.

## Changes
- **New**: `scripts/tmux-mouse-toggle.sh` - Clean mouse toggle logic
- **New**: `scripts/tmux-status-bar.sh` - Version check and status display
- **Modified**: `install.sh` - Auto-install helper scripts to `~/.local/bin`
- **Modified**: `.goreleaser.yml` - Include scripts in releases and Homebrew formula
- **Modified**: `README.md` - Simplified F12 setup from complex one-liner to clean script calls

## Benefits
- ✅ Better code organization and maintainability
- ✅ Easier to debug and extend F12 functionality
- ✅ Cleaner README documentation
- ✅ Scripts can be reused by other tools

## Before
```bash
# Complex one-liner that's hard to read and maintain
bind-key -n F12 run-shell "if tmux show-option -gv mouse | grep -q on; then tmux set-option -g mouse off && tmux display-message 'Mouse: OFF'; else tmux set-option -g mouse on && tmux display-message 'Mouse: ON'; fi; tmux refresh-client -S"
```

## After
```bash
# Simple, clean, maintainable
bind-key -n F12 run-shell "~/.local/bin/claude-dashboard-mouse-toggle"
```

Closes #31