### PR TITLE
(#33) feat: embed helper scripts with auto-setup on first run

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,5 +47,18 @@ brews:
     license: "MIT"
     install: |
       bin.install "claude-dashboard"
-      bin.install "scripts/tmux-mouse-toggle.sh" => "claude-dashboard-mouse-toggle"
-      bin.install "scripts/tmux-status-bar.sh" => "claude-dashboard-status-bar"
+    post_install: |
+      # Helper scripts are embedded in the binary
+      # They will be installed automatically on first run
+      system "#{bin}/claude-dashboard", "setup" rescue nil
+    caveats: |
+      Setup is automatic on first run, or run manually:
+        claude-dashboard setup
+
+      This will:
+      - Install helper scripts to ~/.local/bin/
+      - Configure ~/.tmux.conf for F12 mouse toggle
+      - Add status bar with version info
+
+      To start using claude-dashboard:
+        claude-dashboard

--- a/README.md
+++ b/README.md
@@ -22,13 +22,23 @@
 
 ```bash
 brew install seunggabi/tap/claude-dashboard
+# Setup is automatic on first run, or run manually:
+claude-dashboard setup
 ```
 
 ### Manual Installation
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/seunggabi/claude-dashboard/main/install.sh | bash
+# Setup is automatic on first run, or run manually:
+claude-dashboard setup
 ```
+
+**Setup includes:**
+- ✅ Installs helper scripts to `~/.local/bin/`
+- ✅ Configures `~/.tmux.conf` for F12 mouse toggle
+- ✅ Adds status bar with version info
+- ✅ Enables mouse mode by default
 
 This deploys the binary to `~/.local/bin`. For a custom binary name:
 
@@ -185,26 +195,18 @@ Mouse mode is enabled by default for smooth scrolling. To copy text:
 - **ON** (default): Mouse wheel scrolling enabled, use `Option`/`Shift` + drag to copy text
 - **OFF**: Easy text selection by dragging (no modifier key needed), scroll with `Ctrl+B [`
 
-**Setup (Required)**:
-Add these lines to your `~/.tmux.conf`:
-
+**Setup**:
+Setup is **automatic on first run**, or you can run it manually:
 ```bash
-# F12 key binding for mouse mode toggle
-bind-key -n F12 run-shell "~/.local/bin/claude-dashboard-mouse-toggle"
-
-# Status bar with version check and mouse status (updates every hour)
-set -g status-right-length 80
-set -g status-right "#(~/.local/bin/claude-dashboard-status-bar) | [F12] Mouse:#{?mouse,ON,OFF} | %H:%M"
-set -g status-interval 5
-
-# Enable mouse mode by default
-set -g mouse on
+claude-dashboard setup
 ```
 
-Then reload:
-```bash
-tmux source-file ~/.tmux.conf
-```
+This will:
+- Install helper scripts (`claude-dashboard-mouse-toggle`, `claude-dashboard-status-bar`) to `~/.local/bin/`
+- Add F12 key binding to `~/.tmux.conf`
+- Configure status bar with version check and mouse status
+- Enable mouse mode by default
+- Reload tmux configuration if tmux is running
 
 ### Create Session (TUI)
 
@@ -349,6 +351,9 @@ claude-dashboard attach cd-my-project
 ### General
 
 ```bash
+# Run setup (installs helper scripts and configures tmux)
+claude-dashboard setup
+
 # Show version
 claude-dashboard --version
 

--- a/internal/setup/scripts/tmux-mouse-toggle.sh
+++ b/internal/setup/scripts/tmux-mouse-toggle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Toggle tmux mouse mode and display status
+
+if tmux show-option -gv mouse | grep -q on; then
+    tmux set-option -g mouse off
+    tmux display-message "Mouse: OFF"
+else
+    tmux set-option -g mouse on
+    tmux display-message "Mouse: ON"
+fi
+
+# Refresh client to update status bar immediately
+tmux refresh-client -S

--- a/internal/setup/scripts/tmux-status-bar.sh
+++ b/internal/setup/scripts/tmux-status-bar.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Display claude-dashboard version and update notification in tmux status bar
+
+VERSION_FILE="$HOME/.cache/claude-dashboard/version"
+CURRENT_VERSION_FILE="$HOME/.cache/claude-dashboard/current-version"
+LAST_CHECK_FILE="$HOME/.cache/claude-dashboard/last-check"
+
+# Create cache directory if it doesn't exist
+mkdir -p "$HOME/.cache/claude-dashboard"
+
+# Check for updates every hour
+CURRENT_TIME=$(date +%s)
+LAST_CHECK=0
+if [ -f "$LAST_CHECK_FILE" ]; then
+    LAST_CHECK=$(cat "$LAST_CHECK_FILE")
+fi
+
+# 3600 seconds = 1 hour
+if [ $((CURRENT_TIME - LAST_CHECK)) -gt 3600 ]; then
+    # Get current installed version
+    if command -v claude-dashboard &> /dev/null; then
+        CURRENT=$(claude-dashboard --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "v0.0.0")
+        echo "$CURRENT" > "$CURRENT_VERSION_FILE"
+    fi
+
+    # Get latest version from GitHub
+    LATEST=$(curl -s https://api.github.com/repos/seunggabi/claude-dashboard/releases/latest | grep -oE '"tag_name": "v[0-9]+\.[0-9]+\.[0-9]+"' | cut -d'"' -f4 || echo "")
+
+    if [ -n "$LATEST" ]; then
+        echo "$LATEST" > "$VERSION_FILE"
+    fi
+
+    echo "$CURRENT_TIME" > "$LAST_CHECK_FILE"
+fi
+
+# Read cached version info
+CURRENT="v0.0.0"
+LATEST=""
+if [ -f "$CURRENT_VERSION_FILE" ]; then
+    CURRENT=$(cat "$CURRENT_VERSION_FILE")
+fi
+if [ -f "$VERSION_FILE" ]; then
+    LATEST=$(cat "$VERSION_FILE")
+fi
+
+# Display version with update notification
+if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
+    echo "📦 $CURRENT → $LATEST"
+else
+    echo "✓ $CURRENT"
+fi

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1,0 +1,181 @@
+package setup
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed scripts/tmux-mouse-toggle.sh
+var mouseToggleScript []byte
+
+//go:embed scripts/tmux-status-bar.sh
+var statusBarScript []byte
+
+// InstallScripts installs the helper scripts to ~/.local/bin
+func InstallScripts() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	binDir := filepath.Join(homeDir, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
+	// Install mouse toggle script
+	mouseTogglePath := filepath.Join(binDir, "claude-dashboard-mouse-toggle")
+	if err := os.WriteFile(mouseTogglePath, mouseToggleScript, 0755); err != nil {
+		return fmt.Errorf("failed to write mouse toggle script: %w", err)
+	}
+
+	// Install status bar script
+	statusBarPath := filepath.Join(binDir, "claude-dashboard-status-bar")
+	if err := os.WriteFile(statusBarPath, statusBarScript, 0755); err != nil {
+		return fmt.Errorf("failed to write status bar script: %w", err)
+	}
+
+	return nil
+}
+
+// SetupTmuxConfig adds the required tmux configuration
+func SetupTmuxConfig() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	tmuxConfPath := filepath.Join(homeDir, ".tmux.conf")
+
+	// Read existing config
+	var existingConfig string
+	if data, err := os.ReadFile(tmuxConfPath); err == nil {
+		existingConfig = string(data)
+	}
+
+	// Check if already configured
+	if strings.Contains(existingConfig, "claude-dashboard-mouse-toggle") {
+		return nil // Already configured
+	}
+
+	// Configuration to add
+	config := `
+# claude-dashboard: F12 key binding for mouse mode toggle
+bind-key -n F12 run-shell "~/.local/bin/claude-dashboard-mouse-toggle"
+
+# claude-dashboard: Status bar with version check and mouse status
+set -g status-right-length 80
+set -g status-right "#(~/.local/bin/claude-dashboard-status-bar) | [F12] Mouse:#{?mouse,ON,OFF} | %H:%M"
+set -g status-interval 5
+
+# claude-dashboard: Enable mouse mode by default
+set -g mouse on
+`
+
+	// Append configuration
+	f, err := os.OpenFile(tmuxConfPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open tmux config: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(config); err != nil {
+		return fmt.Errorf("failed to write tmux config: %w", err)
+	}
+
+	return nil
+}
+
+// ReloadTmuxConfig reloads the tmux configuration
+func ReloadTmuxConfig() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	tmuxConfPath := filepath.Join(homeDir, ".tmux.conf")
+
+	cmd := exec.Command("tmux", "source-file", tmuxConfPath)
+	if err := cmd.Run(); err != nil {
+		// Ignore error if tmux is not running
+		return nil
+	}
+
+	return nil
+}
+
+// Setup performs the complete setup
+func Setup(silent bool) error {
+	if !silent {
+		fmt.Println("🔧 Installing claude-dashboard helper scripts...")
+	}
+
+	if err := InstallScripts(); err != nil {
+		return fmt.Errorf("failed to install scripts: %w", err)
+	}
+
+	if !silent {
+		fmt.Println("✅ Helper scripts installed to ~/.local/bin/")
+		fmt.Println()
+		fmt.Println("🔧 Configuring tmux...")
+	}
+
+	if err := SetupTmuxConfig(); err != nil {
+		return fmt.Errorf("failed to setup tmux config: %w", err)
+	}
+
+	if !silent {
+		fmt.Println("✅ Tmux configuration added to ~/.tmux.conf")
+		fmt.Println()
+		fmt.Println("🔄 Reloading tmux configuration...")
+	}
+
+	if err := ReloadTmuxConfig(); err != nil {
+		if !silent {
+			fmt.Println("⚠️  Could not reload tmux (not running). Configuration will apply on next tmux start.")
+		}
+	} else {
+		if !silent {
+			fmt.Println("✅ Tmux configuration reloaded")
+		}
+	}
+
+	if !silent {
+		fmt.Println()
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println("  🎉 Setup complete!")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println()
+		fmt.Println("  Press F12 in tmux to toggle mouse mode")
+		fmt.Println("  Check the status bar for version and mouse status")
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// CheckSetup checks if setup has been completed
+func CheckSetup() bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	binDir := filepath.Join(homeDir, ".local", "bin")
+	mouseTogglePath := filepath.Join(binDir, "claude-dashboard-mouse-toggle")
+	statusBarPath := filepath.Join(binDir, "claude-dashboard-status-bar")
+
+	// Check if both scripts exist
+	if _, err := os.Stat(mouseTogglePath); err != nil {
+		return false
+	}
+	if _, err := os.Stat(statusBarPath); err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary
Embeds helper scripts in the binary and adds automatic setup on first run to fix F12 and status bar issues on other Macs.

## Changes
- ✅ Embed `tmux-mouse-toggle.sh` and `tmux-status-bar.sh` using Go embed
- ✅ Add `internal/setup` package for automatic installation
- ✅ Auto-setup runs before any command (except --version/--help)
- ✅ Homebrew post_install hook runs setup automatically
- ✅ Add manual `claude-dashboard setup` command
- ✅ Update README with automatic setup instructions

## Benefits
- One-command installation (brew/curl) - no manual configuration
- F12 and status bar work immediately on any Mac
- Works with any installation method (brew, curl, go install)

## Testing
- [x] Build succeeds
- [x] Help command works
- [x] Auto-setup logic added before all commands

Closes #33