### PR TITLE
(#35) feat: add ctrl+k to kill all idle sessions at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,20 +124,21 @@ If you've used [k9s](https://k9scli.io/), you'll feel right at home. Vim-style n
 
 ### Dashboard
 
-| Key       | Action                           |
-|-----------|----------------------------------|
-| `↑` / `k` | Move cursor up                   |
-| `↓` / `j` | Move cursor down                 |
-| `enter`   | Attach to session                |
-| `n`       | Create new session               |
-| `K`       | Kill session (with confirmation) |
-| `l`       | View session logs                |
-| `d`       | Session detail view              |
-| `/`       | Filter / search sessions         |
-| `r`       | Manual refresh                   |
-| `?`       | Help overlay                     |
-| `esc`     | Go back / cancel                 |
-| `q`       | Quit                             |
+| Key       | Action                                    |
+|-----------|-------------------------------------------|
+| `↑` / `k` | Move cursor up                            |
+| `↓` / `j` | Move cursor down                          |
+| `enter`   | Attach to session                         |
+| `n`       | Create new session                        |
+| `K`       | Kill session (with confirmation)          |
+| `ctrl+k`  | Kill all idle sessions (with confirmation)|
+| `l`       | View session logs                         |
+| `d`       | Session detail view                       |
+| `/`       | Filter / search sessions                  |
+| `r`       | Manual refresh                            |
+| `?`       | Help overlay                              |
+| `esc`     | Go back / cancel                          |
+| `q`       | Quit                                      |
 
 ### Logs Viewer
 

--- a/cmd/claude-dashboard/main.go
+++ b/cmd/claude-dashboard/main.go
@@ -154,6 +154,7 @@ Keybindings:
   enter   Attach to session
   n       New session
   K       Kill session
+  ctrl+k  Kill all idle sessions
   l       View logs
   d       Session detail
   /       Filter


### PR DESCRIPTION
## Summary
Adds a new `ctrl+k` keybinding to kill all idle sessions at once, making it easy to clean up multiple idle sessions quickly.

## Changes
- ✅ Add `ctrl+k` keybinding for bulk kill
- ✅ Add confirmation prompt: "Kill N idle session(s)? (y/n)"
- ✅ Filter and kill only idle managed sessions
- ✅ Error handling for failed kills
- ✅ Update README keybindings table
- ✅ Update help message

## Implementation Details
```
internal/app/app.go:
  - killingIdle flag for bulk kill mode
  - getIdleSessions() - filter idle sessions
  - killIdleSessions() - kill all with error handling
  - handleConfirmKey() - support both single and bulk kill
```

## Usage
1. Press `ctrl+k` in dashboard
2. Confirm: "Kill N idle session(s)? (y/n)"
3. All idle sessions killed at once

## Before/After
**Before:** Kill idle sessions one by one with `K`
**After:** Kill all idle sessions at once with `ctrl+k` ✨

Closes #35