### PR TITLE
(#37) fix: correct version detection in tmux status bar

### DIFF
--- a/internal/setup/scripts/tmux-status-bar.sh
+++ b/internal/setup/scripts/tmux-status-bar.sh
@@ -19,7 +19,7 @@ fi
 if [ $((CURRENT_TIME - LAST_CHECK)) -gt 3600 ]; then
     # Get current installed version
     if command -v claude-dashboard &> /dev/null; then
-        CURRENT=$(claude-dashboard --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "v0.0.0")
+        CURRENT=$(claude-dashboard --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^/v/' || echo "v0.0.0")
         echo "$CURRENT" > "$CURRENT_VERSION_FILE"
     fi
 

--- a/scripts/tmux-status-bar.sh
+++ b/scripts/tmux-status-bar.sh
@@ -19,7 +19,7 @@ fi
 if [ $((CURRENT_TIME - LAST_CHECK)) -gt 3600 ]; then
     # Get current installed version
     if command -v claude-dashboard &> /dev/null; then
-        CURRENT=$(claude-dashboard --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "v0.0.0")
+        CURRENT=$(claude-dashboard --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^/v/' || echo "v0.0.0")
         echo "$CURRENT" > "$CURRENT_VERSION_FILE"
     fi
 


### PR DESCRIPTION
## Summary

Fixes #37 - tmux status bar incorrectly showing `v0.0.0 → v0.9.0` when v0.9.0 is properly installed.

## Problem

The version extraction regex pattern required a 'v' prefix, but `claude-dashboard --version` outputs `claude-dashboard 0.9.0` (without 'v').

## Changes

- Updated regex from `'v[0-9]+\.[0-9]+\.[0-9]+'` to `'[0-9]+\.[0-9]+\.[0-9]+'`
- Added `sed 's/^/v/'` to prepend 'v' after extraction
- Applied fix to both script locations:
  - `scripts/tmux-status-bar.sh`
  - `internal/setup/scripts/tmux-status-bar.sh`

## Test Plan

- [x] Version extraction works correctly: `claude-dashboard --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^/v/'` → `v0.9.0`
- [x] Cache updated correctly: `~/.cache/claude-dashboard/current-version` contains `v0.9.0`
- [x] Status bar displays correctly: `✓ v0.9.0` instead of `📦 v0.0.0 → v0.9.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #37