### PR TITLE
(#39) fix: auto-update version cache and fix homebrew script installation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,12 +47,27 @@ brews:
     license: "MIT"
     install: |
       bin.install "claude-dashboard"
+      # Install helper scripts to a temporary location for setup to use
+      libexec.install "scripts/tmux-mouse-toggle.sh"
+      libexec.install "scripts/tmux-status-bar.sh"
     post_install: |
-      # Helper scripts are embedded in the binary
-      # They will be installed automatically on first run
-      system "#{bin}/claude-dashboard", "setup" rescue nil
+      # Run setup to install scripts and configure tmux
+      # Copy scripts from libexec to ~/.local/bin
+      home = Dir.home
+      local_bin = File.join(home, ".local", "bin")
+      FileUtils.mkdir_p(local_bin)
+
+      FileUtils.cp(File.join(libexec, "tmux-mouse-toggle.sh"), File.join(local_bin, "claude-dashboard-mouse-toggle"))
+      FileUtils.cp(File.join(libexec, "tmux-status-bar.sh"), File.join(local_bin, "claude-dashboard-status-bar"))
+      FileUtils.chmod(0755, File.join(local_bin, "claude-dashboard-mouse-toggle"))
+      FileUtils.chmod(0755, File.join(local_bin, "claude-dashboard-status-bar"))
+
+      # Run setup to configure tmux
+      system "#{bin}/claude-dashboard", "setup"
     caveats: |
-      Setup is automatic on first run, or run manually:
+      Setup was automatically run during installation.
+
+      If you need to re-run setup:
         claude-dashboard setup
 
       This will:

--- a/cmd/claude-dashboard/main.go
+++ b/cmd/claude-dashboard/main.go
@@ -24,7 +24,7 @@ func main() {
 			if !setup.CheckSetup() {
 				fmt.Println("📦 First time setup detected...")
 				fmt.Println()
-				if err := setup.Setup(false); err != nil {
+				if err := setup.Setup(false, version); err != nil {
 					fmt.Fprintf(os.Stderr, "Auto-setup failed: %v\n", err)
 					fmt.Println()
 					fmt.Println("You can run 'claude-dashboard setup' manually later.")
@@ -37,7 +37,7 @@ func main() {
 		if !setup.CheckSetup() {
 			fmt.Println("📦 First time setup detected...")
 			fmt.Println()
-			if err := setup.Setup(false); err != nil {
+			if err := setup.Setup(false, version); err != nil {
 				fmt.Fprintf(os.Stderr, "Auto-setup failed: %v\n", err)
 				fmt.Println()
 				fmt.Println("You can run 'claude-dashboard setup' manually later.")
@@ -55,7 +55,7 @@ func main() {
 			printHelp()
 			os.Exit(0)
 		case "setup":
-			if err := setup.Setup(false); err != nil {
+			if err := setup.Setup(false, version); err != nil {
 				fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
## Summary

This PR fixes three related issues:

1. **Version cache auto-update**: After upgrading via Homebrew, the version cache now automatically updates during setup
2. **Homebrew script installation**: Helper scripts are now properly installed to `~/.local/bin/` during Homebrew installation
3. **Duplicate tmux config cleanup**: Old/duplicate tmux configurations are removed before adding new ones

## Changes

### `.goreleaser.yml`
- Install helper scripts to `libexec` during package build
- Copy scripts from `libexec` to `~/.local/bin/` in `post_install`
- Run setup after installation to configure tmux

### `cmd/claude-dashboard/main.go`
- Pass `version` parameter to `Setup()` function

### `internal/setup/setup.go`
- Add `UpdateVersionCache(version)` function to update `~/.cache/claude-dashboard/current-version`
- Add logic to remove old/duplicate claude-dashboard configurations from `~/.tmux.conf`
- Call `UpdateVersionCache()` during setup

## Testing

```bash
# Build and test
go build -ldflags "-X main.version=0.9.2" -o /tmp/claude-dashboard-test ./cmd/claude-dashboard

# Test version cache update
/tmp/claude-dashboard-test setup
cat ~/.cache/claude-dashboard/current-version  # Should show v0.9.2

# Test tmux config cleanup
cat ~/.tmux.conf | grep -A 10 "claude-dashboard"  # Should have no duplicates
```

## Fixes

Closes #39