### PR TITLE
(#41) fix: auto-update version cache on launch and improve mouse support

### DIFF
--- a/cmd/claude-dashboard/main.go
+++ b/cmd/claude-dashboard/main.go
@@ -16,6 +16,12 @@ func main() {
 	app.Version = version
 	app.DrainStdin()
 
+	// Always update version cache on startup (important for Homebrew upgrades)
+	// This is silent and fast, so it won't impact user experience
+	if version != "" && version != "dev" {
+		_ = setup.UpdateVersionCache(version)
+	}
+
 	// Auto-setup on first run (before any command)
 	// Skip for --version, --help, and setup commands
 	if len(os.Args) > 1 {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -102,11 +102,14 @@ bind-key -n F12 run-shell "~/.local/bin/claude-dashboard-mouse-toggle"
 
 # claude-dashboard: Status bar with version check and mouse status
 set -g status-right-length 80
-set -g status-right "#(~/.local/bin/claude-dashboard-status-bar) | [F12] Mouse:#{?mouse,ON,OFF} | %H:%M"
+set -g status-right "#(~/.local/bin/claude-dashboard-status-bar) | [F12] #[fg=#{?mouse,green,red}]Mouse:#{?mouse,ON,OFF}#[default] | %H:%M"
 set -g status-interval 5
 
 # claude-dashboard: Enable mouse mode by default
 set -g mouse on
+
+# claude-dashboard: Terminal overrides for better mouse support
+set -g terminal-overrides 'xterm*:smcup@:rmcup@'
 `
 
 	// Write cleaned config with new configuration


### PR DESCRIPTION
## Summary

This PR fixes version cache staleness after Homebrew upgrades and improves mouse support across different terminal emulators.

## Changes

### 1. Auto-update version cache on every launch
- Version cache now updates on every app startup in `main()`
- Fixes the issue where Homebrew `post_install` only runs on fresh install, not upgrade
- Silent and fast, no impact on user experience

### 2. Improve mouse scrolling support
- Add `terminal-overrides 'xterm*:smcup@:rmcup@'` to tmux config
- Better compatibility with iTerm2, Terminal.app, Alacritty, etc.

### 3. Color-coded mouse status
- 🟢 Mouse:ON → Green
- 🔴 Mouse:OFF → Red
- Easier to see mouse mode status at a glance

## Testing

```bash
# Build and test
go build -o /tmp/test ./cmd/claude-dashboard

# Test version cache auto-update
/tmp/test --version
cat ~/.cache/claude-dashboard/current-version  # Should match

# Test setup with new config
/tmp/test setup
cat ~/.tmux.conf | grep -A 15 "claude-dashboard"

# Test in tmux
tmux source ~/.tmux.conf
# Press F12 to toggle - status should show color-coded ON/OFF
```

## Fixes

Closes #41