### PR TITLE
fix: resolve working directory bug when creating sessions via TUI

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -280,7 +280,11 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "n":
 		m.view = ViewCreate
-		m.createForm = ui.NewCreateForm(m.cfg.DefaultDir)
+		defaultDir := m.cfg.DefaultDir
+		if defaultDir == "" {
+			defaultDir, _ = os.Getwd()
+		}
+		m.createForm = ui.NewCreateForm(defaultDir)
 		return m, m.createForm.NameInput.Focus()
 	case "K":
 		sessions := m.filteredSessions()

--- a/internal/ui/create.go
+++ b/internal/ui/create.go
@@ -25,7 +25,7 @@ func NewCreateForm(defaultDir string) CreateForm {
 	nameInput.Focus()
 
 	dirInput := textinput.New()
-	dirInput.Placeholder = "/path/to/project"
+	dirInput.Placeholder = "/absolute/path/to/project"
 	dirInput.CharLimit = 200
 	dirInput.Width = 60
 	if defaultDir != "" {


### PR DESCRIPTION
## Problem

When creating a session via the TUI form (`n` key), the session sometimes opens in the directory where `claude-dashboard` was started rather than the directory the user specified.

Three root causes:

1. **Relative paths pass through silently** — if `cfg.DefaultDir` is `"."` or the user types a relative path, tmux resolves it relative to the dashboard's own CWD.
2. **No existence check** — if the path doesn't exist, tmux silently falls back to its server CWD with no feedback to the user.
3. **UX gap** — when `cfg.DefaultDir` is empty the directory field is blank, so users don't know what default they'll get.

## Changes

- **`internal/session/manager.go`**: Added `resolvePath` helper that expands `~` and converts relative paths to absolute. `Create()` now resolves the path and validates it exists and is a directory before passing it to tmux, returning a clear error on failure.
- **`internal/app/app.go`**: The `n` key handler defaults the directory field to `os.Getwd()` when `cfg.DefaultDir` is empty, so users see where sessions will open.
- **`internal/ui/create.go`**: Updated placeholder to `/absolute/path/to/project` to hint users toward absolute paths.

## Tests

Added 7 new tests in `manager_test.go` covering `resolvePath` (absolute passthrough, `~/` expansion, relative→absolute, `.`→cwd) and `Create()` path validation (non-existent path, file instead of directory, tilde expansion).

## Verification

1. Press `n` — directory field pre-fills with current working directory
2. Submit without changing directory — session opens in the pre-filled dir
3. Enter `~/projects/myapp` — `~` expands correctly
4. Enter a non-existent path — shows "directory does not exist" error in the form
5. Attach to a session, run `pwd` — shows the specified directory