### PR TITLE
fix: handle edge cases in path resolution

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -282,7 +282,11 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.view = ViewCreate
 		defaultDir := m.cfg.DefaultDir
 		if defaultDir == "" {
-			defaultDir, _ = os.Getwd()
+			if cwd, err := os.Getwd(); err == nil {
+				defaultDir = cwd
+			} else {
+				defaultDir, _ = os.UserHomeDir()
+			}
 		}
 		m.createForm = ui.NewCreateForm(defaultDir)
 		return m, m.createForm.NameInput.Focus()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -13,6 +13,9 @@ import (
 
 // resolvePath expands ~ and converts relative paths to absolute.
 func resolvePath(path string) (string, error) {
+	if path == "~" {
+		return os.UserHomeDir()
+	}
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -94,20 +94,18 @@ func TestCreate_filePathReturnsNotADirectoryError(t *testing.T) {
 	}
 }
 
-func TestCreate_tildeDirectoryExpandsAndValidates(t *testing.T) {
+func TestResolvePath_bareTildeExpandsToHome(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home dir")
 	}
-	// Home dir exists, so resolution should succeed and reach tmux (nil client panics).
-	// We expect a panic/nil-deref only if path validation passes — use recover to confirm.
-	mgr := &Manager{client: nil}
-	func() {
-		defer func() { recover() }() // nil client will panic inside NewSession
-		_ = mgr.Create(context.Background(), "test", "~/", "")
-		_ = home // used above
-	}()
-	// If we get here without a "directory does not exist" error, ~ expanded correctly.
+	got, err := resolvePath("~")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != home {
+		t.Errorf("expected %q, got %q", home, got)
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Follow-up fixes for #48. Apply after merging #48.

- Handle bare `~` input in `resolvePath` (previously only `~/` was expanded, bare `~` became `/cwd/~`)
- Add `os.UserHomeDir()` fallback when `os.Getwd()` fails in TUI form default directory
- Replace unreliable `recover()`-based test with direct `resolvePath("~")` assertion

## Depends on
- #48

## Test plan
- [x] All 7 tests pass (`go test ./internal/session/ -v`)
- [ ] Verify `~` input resolves to home directory in TUI form
- [ ] Verify TUI form shows home directory when CWD is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)